### PR TITLE
Bump internal crate versions to 0.1.7 and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cargo-rustapi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.22.1",
  "brotli 6.0.0",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-extras"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytes",
  "cookie",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-openapi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytes",
  "http",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-rs"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "rustapi-core",
  "rustapi-extras",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-toon"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-validate"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "http",
  "serde",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-view"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytes",
  "http",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-ws"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "toon-bench"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "criterion",
  "serde",
@@ -4053,6 +4053,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["RustAPI Contributors"]
 license = "MIT OR Apache-2.0"
@@ -84,7 +84,7 @@ uuid = { version = "1.6", features = ["v4"] }
 prometheus = "0.13"
 
 # OpenAPI
-utoipa = { version = "4.2" }
+utoipa = { version = "4.2", features = ["uuid", "chrono"] }
 
 # TOON format
 toon-format = { version = "0.4", default-features = false }
@@ -106,12 +106,12 @@ indicatif = "0.17"
 console = "0.15"
 
 # Internal crates
-rustapi-core = { path = "crates/rustapi-core", version = "0.1.6", default-features = false }
-rustapi-macros = { path = "crates/rustapi-macros", version = "0.1.6" }
-rustapi-validate = { path = "crates/rustapi-validate", version = "0.1.6" }
-rustapi-openapi = { path = "crates/rustapi-openapi", version = "0.1.6", default-features = false }
-rustapi-extras = { path = "crates/rustapi-extras", version = "0.1.6" }
-rustapi-toon = { path = "crates/rustapi-toon", version = "0.1.6" }
-rustapi-ws = { path = "crates/rustapi-ws", version = "0.1.6" }
-rustapi-view = { path = "crates/rustapi-view", version = "0.1.6" }
+rustapi-core = { path = "crates/rustapi-core", version = "0.1.7", default-features = false }
+rustapi-macros = { path = "crates/rustapi-macros", version = "0.1.7" }
+rustapi-validate = { path = "crates/rustapi-validate", version = "0.1.7" }
+rustapi-openapi = { path = "crates/rustapi-openapi", version = "0.1.7", default-features = false }
+rustapi-extras = { path = "crates/rustapi-extras", version = "0.1.7" }
+rustapi-toon = { path = "crates/rustapi-toon", version = "0.1.7" }
+rustapi-ws = { path = "crates/rustapi-ws", version = "0.1.7" }
+rustapi-view = { path = "crates/rustapi-view", version = "0.1.7" }
 


### PR DESCRIPTION
This pull request updates the project dependencies and configuration in `Cargo.toml` to keep the codebase up to date and improve OpenAPI integration. The most important changes are version bumps for internal crates and enhancements to the OpenAPI tooling.

Dependency and version updates:

* Updated the project version from `0.1.6` to `0.1.7` in the `[workspace.package]` section.
* Bumped all internal crate dependencies (such as `rustapi-core`, `rustapi-macros`, `rustapi-validate`, etc.) from version `0.1.6` to `0.1.7` to ensure consistency across the workspace.

OpenAPI and feature enhancements:

* Enabled the `uuid` and `chrono` features for the `utoipa` OpenAPI dependency, improving schema support for UUID and date/time types in OpenAPI documentation.