### PR TITLE
Add UI-only route tests and remove unused mut from mount_route_ui

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,13 +43,25 @@ async fn hello(Path(name): Path<String>) -> Json<Message> {
     Json(Message { greeting: format!("Hello, {name}!") })
 }
 
+async fn homepage() -> Html<&'static str> {
+    Html("<h1>Welcome</h1>")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    RustApi::auto().run("0.0.0.0:8080").await
+    RustApi::new()
+        // API routes show up in OpenAPI under /api/*
+        .route("/api/hello/{name}", get(hello))
+        // UI/SSR routes are mounted without OpenAPI entries by default
+        .route_ui("/", get(homepage))
+        .run("0.0.0.0:8080")
+        .await
 }
 ```
 
-Visit `http://localhost:8080/docs` for auto-generated Swagger UI.
+Visit `http://localhost:8080/docs` for auto-generated Swagger UI. Routes under `/api/*`
+are included in OpenAPI by default, while UI routes mounted with `route_ui`/`mount_route_ui`
+are excluded unless you register them as API routes.
 
 ## Examples
 


### PR DESCRIPTION
### Motivation
- Verify that UI/SSR routes mounted via `route_ui`/`mount_route_ui` are registered with the router but are excluded from the OpenAPI spec.
- Eliminate an unnecessary `mut` from the `mount_route_ui` signature to remove a compiler warning and tidy the API.

### Description
- Added two unit tests `test_route_ui_excludes_openapi` and `test_mount_route_ui_excludes_openapi` to `crates/rustapi-core/src/app.rs` which assert UI routes are mounted while `openapi_spec().paths` remains empty.
- Imported `crate::handler::Route` into the test module and adjusted test assertions to check `app.openapi_spec()` before calling `into_router()`.
- Removed the unused `mut` from the `pub fn mount_route_ui(self, ...)` signature to address an `unused_mut` warning.

### Testing
- Ran `cargo test -p rustapi-core --lib` and all tests completed successfully with `205 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb254e42083238d5485e9f0727a67)