### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix directory traversal vulnerability in static file serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "linkme",
  "matchit 0.7.3",
  "multer",
+ "percent-encoding",
  "pin-project-lite",
  "prometheus",
  "proptest",

--- a/crates/rustapi-core/Cargo.toml
+++ b/crates/rustapi-core/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+percent-encoding = "2.3"
 # Async
 tokio = { workspace = true, features = ["rt", "net", "time", "fs", "macros", "io-util"] }
 futures-util = { workspace = true }

--- a/crates/rustapi-core/src/static_files.rs
+++ b/crates/rustapi-core/src/static_files.rs
@@ -253,8 +253,13 @@ impl StaticFile {
         relative_path: &str,
         config: &StaticFileConfig,
     ) -> Result<Response, ApiError> {
-        // Sanitize path to prevent directory traversal
-        let clean_path = sanitize_path(relative_path);
+        // Percent-decode the path first
+        let decoded_path = percent_encoding::percent_decode_str(relative_path)
+            .decode_utf8()
+            .unwrap_or(std::borrow::Cow::Borrowed(relative_path));
+
+        // Sanitize path to prevent basic directory traversal
+        let clean_path = sanitize_path(&decoded_path);
         let file_path = config.root.join(&clean_path);
 
         // Check if it's a directory
@@ -282,6 +287,21 @@ impl StaticFile {
 
     /// Serve a specific file
     async fn serve_file(path: &Path, config: &StaticFileConfig) -> Result<Response, ApiError> {
+        // Security check: ensure the resolved path is within the root directory
+        let canonical_root = match tokio::fs::canonicalize(&config.root).await {
+            Ok(root) => root,
+            Err(_) => return Err(ApiError::internal("Static file root directory not found")),
+        };
+
+        let canonical_file = match tokio::fs::canonicalize(path).await {
+            Ok(file) => file,
+            Err(_) => return Err(ApiError::not_found("File not found")),
+        };
+
+        if !canonical_file.starts_with(&canonical_root) {
+            return Err(ApiError::not_found("File not found"));
+        }
+
         // Check if file exists
         let metadata = fs::metadata(path)
             .await

--- a/crates/rustapi-core/tests/static_files_security_test.rs
+++ b/crates/rustapi-core/tests/static_files_security_test.rs
@@ -1,0 +1,47 @@
+use rustapi_core::static_files::serve_dir;
+use rustapi_core::static_files::StaticFile;
+use std::fs::File;
+
+#[tokio::test]
+async fn test_directory_traversal_blocked() {
+    let config = serve_dir("/static", "./"); // root is crates/rustapi-core
+
+    // We try to access something outside the root
+    let relative_path = "../../etc/passwd";
+    let res = StaticFile::serve(relative_path, &config).await;
+    assert!(res.is_err(), "Standard traversal should be blocked");
+
+    // Percent encoded payload
+    let relative_path_encoded = "..%2F..%2Fetc%2Fpasswd";
+    let res_encoded = StaticFile::serve(relative_path_encoded, &config).await;
+    assert!(res_encoded.is_err(), "Encoded traversal should be blocked");
+
+    // Double encoded
+    let relative_path_double = "%2e%2e%2f%2e%2e%2fetc%2fpasswd";
+    let res_double = StaticFile::serve(relative_path_double, &config).await;
+    assert!(res_double.is_err(), "Double encoded traversal should be blocked");
+}
+
+#[tokio::test]
+async fn test_valid_file_served() {
+    let config = serve_dir("/static", "./");
+
+    // Valid file
+    let relative_path = "src/lib.rs";
+    let res = StaticFile::serve(relative_path, &config).await;
+    assert!(res.is_ok(), "Valid file should be served");
+}
+
+#[tokio::test]
+async fn test_valid_file_with_spaces_served() {
+    let _ = std::fs::create_dir_all("./test_dir");
+    let _ = File::create("./test_dir/file with spaces.txt");
+
+    let config = serve_dir("/static", "./test_dir");
+
+    let relative_path = "file%20with%20spaces.txt";
+    let res = StaticFile::serve(relative_path, &config).await;
+    assert!(res.is_ok(), "File with percent-encoded spaces should be served");
+
+    let _ = std::fs::remove_dir_all("./test_dir");
+}

--- a/crates/rustapi-core/tests/static_files_security_test.rs
+++ b/crates/rustapi-core/tests/static_files_security_test.rs
@@ -19,7 +19,10 @@ async fn test_directory_traversal_blocked() {
     // Double encoded
     let relative_path_double = "%2e%2e%2f%2e%2e%2fetc%2fpasswd";
     let res_double = StaticFile::serve(relative_path_double, &config).await;
-    assert!(res_double.is_err(), "Double encoded traversal should be blocked");
+    assert!(
+        res_double.is_err(),
+        "Double encoded traversal should be blocked"
+    );
 }
 
 #[tokio::test]
@@ -41,7 +44,10 @@ async fn test_valid_file_with_spaces_served() {
 
     let relative_path = "file%20with%20spaces.txt";
     let res = StaticFile::serve(relative_path, &config).await;
-    assert!(res.is_ok(), "File with percent-encoded spaces should be served");
+    assert!(
+        res.is_ok(),
+        "File with percent-encoded spaces should be served"
+    );
 
     let _ = std::fs::remove_dir_all("./test_dir");
 }


### PR DESCRIPTION
This PR secures the `StaticFile` serving module in `rustapi-core` against directory traversal and Local File Inclusion (LFI) vulnerabilities.

### Vulnerability
Previously, the `sanitize_path` function attempted to prevent directory traversal by stripping literal `..` segments. However, this could be bypassed using URL percent-encoding (e.g., `%2e%2e%2f` for `../`), as the path was not decoded before sanitization. Depending on the routing layer configuration, this could allow attackers to access files outside the intended root directory.

### Fix
This PR implements a robust defense-in-depth approach:
1. **URL Decoding**: The incoming relative path is now explicitly decoded using `percent_encoding::percent_decode_str` before any processing occurs.
2. **Path Canonicalization**: The system now utilizes `tokio::fs::canonicalize` on both the static file root directory and the requested file path.
3. **Boundary Verification**: The server explicitly checks if the canonicalized file path `starts_with` the canonicalized root directory. If it doesn't, it returns a 404 Not Found. This completely eliminates the possibility of serving files outside the intended directory tree, regardless of symlinks or complex encoding tricks.

New tests have been added to verify that standard and percent-encoded traversal attempts are properly blocked.

---
*PR created automatically by Jules for task [17484869118111250650](https://jules.google.com/task/17484869118111250650) started by @Tuntii*