### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret fallback in templates

### DIFF
--- a/crates/cargo-rustapi/src/templates/full.rs
+++ b/crates/cargo-rustapi/src/templates/full.rs
@@ -170,7 +170,7 @@ pub async fn login(Json(body): Json<LoginRequest>) -> Result<Json<LoginResponse>
     // TODO: Validate credentials against your database
     if body.username == "admin" && body.password == "password" {
         let jwt_secret = std::env::var("JWT_SECRET")
-            .unwrap_or_else(|_| "dev-secret-change-in-production".to_string());
+            .map_err(|_| ApiError::internal("JWT_SECRET environment variable not set"))?;
         
         let claims = UserClaims {
             sub: "1".to_string(),


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `full` project template generated by `cargo-rustapi` contained a hardcoded fallback secret (`"dev-secret-change-in-production"`) that was used if the `JWT_SECRET` environment variable was not set.
🎯 **Impact:** If a user deployed the generated application to production without properly configuring their environment variables, the application would silently start using the known fallback secret. An attacker could use this publicly known secret to forge valid JWT tokens, resulting in a complete authentication and authorization bypass.
🔧 **Fix:** Replaced the `unwrap_or_else` fallback with a `map_err` that returns an `ApiError::internal` when `JWT_SECRET` is missing. This enforces the security principle of "failing securely" and requires the explicit configuration of secrets.
✅ **Verification:** Verified by generating a new project using the full template (or reviewing `cargo test -p cargo-rustapi` output) and ensuring tests pass. In a generated application, the `/auth/login` endpoint will now return a 500 error instead of succeeding with a dummy secret if the `.env` configuration is missing.

---
*PR created automatically by Jules for task [5099679720808285862](https://jules.google.com/task/5099679720808285862) started by @Tuntii*