### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret fallback in templates

### DIFF
--- a/crates/cargo-rustapi/src/templates/full.rs
+++ b/crates/cargo-rustapi/src/templates/full.rs
@@ -170,7 +170,7 @@ pub async fn login(Json(body): Json<LoginRequest>) -> Result<Json<LoginResponse>
     // TODO: Validate credentials against your database
     if body.username == "admin" && body.password == "password" {
         let jwt_secret = std::env::var("JWT_SECRET")
-            .unwrap_or_else(|_| "dev-secret-change-in-production".to_string());
+            .map_err(|_| ApiError::internal("JWT_SECRET environment variable is not set"))?;
         
         let claims = UserClaims {
             sub: "1".to_string(),


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `full` project template in `cargo-rustapi` provided a hardcoded default string (`"dev-secret-change-in-production"`) if the `JWT_SECRET` environment variable was missing.
🎯 **Impact:** Applications generated from this template could be inadvertently deployed to production with a known, insecure default secret if the environment configuration was missed, leading to critical authentication bypasses.
🔧 **Fix:** Replaced `.unwrap_or_else()` with `.map_err()`, returning an `ApiError::internal("JWT_SECRET environment variable is not set")` when the secret is missing.
✅ **Verification:** Verified by running `cargo check` and `cargo test -p cargo-rustapi` to ensure no functionality is broken and templates are correctly generated.

---
*PR created automatically by Jules for task [3037792376267280363](https://jules.google.com/task/3037792376267280363) started by @Tuntii*