### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure JWT secret fallback in template

### DIFF
--- a/crates/cargo-rustapi/src/templates/full.rs
+++ b/crates/cargo-rustapi/src/templates/full.rs
@@ -170,7 +170,7 @@ pub async fn login(Json(body): Json<LoginRequest>) -> Result<Json<LoginResponse>
     // TODO: Validate credentials against your database
     if body.username == "admin" && body.password == "password" {
         let jwt_secret = std::env::var("JWT_SECRET")
-            .unwrap_or_else(|_| "dev-secret-change-in-production".to_string());
+            .map_err(|_| ApiError::internal("JWT_SECRET environment variable is not set"))?;
         
         let claims = UserClaims {
             sub: "1".to_string(),


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `full.rs` project template generated by `cargo-rustapi` included a hardcoded fallback string `"dev-secret-change-in-production"` for the `JWT_SECRET` environment variable. If developers deployed the scaffolded application without explicitly configuring the `JWT_SECRET` environment variable, the application would silently use this predictable secret for token generation.
🎯 Impact: An attacker who knows or discovers this open source fallback string could forge their own valid JWT tokens, completely bypassing authentication and gaining unauthorized access to any system deployed from this template without the environment variable set.
🔧 Fix: Removed the `.unwrap_or_else(...)` fallback in the generated `login` handler. Replaced it with `.map_err(|_| ApiError::internal("JWT_SECRET environment variable is not set"))?` so the system securely fails closed when the required secret is missing.
✅ Verification: Ran `cargo test --workspace` and `cargo check -p cargo-rustapi` to ensure that templates still compile and pass all tests correctly.

---
*PR created automatically by Jules for task [9231154905785874496](https://jules.google.com/task/9231154905785874496) started by @Tuntii*