### PR TITLE
chore(release): v0.2.0 — semantic release + maintenance

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,12 @@
 name: Release Drafter
 
+# Draft notes + PR autolabels only.
+# Tags, GitHub Releases, and crates.io publish are owned by release-plz
+# (.github/workflows/release-plz.yml) from v0.2.0 onward.
 on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -15,26 +16,13 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write  # write releases
+      contents: write  # write draft releases
       pull-requests: read
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref_type == 'branch'
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish_release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref_type == 'tag'
-    steps:
-      - uses: release-drafter/release-drafter@v7
-        with:
-          publish: true
-          tag: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   update_pr_label:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,71 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  # Publish unpublished packages, create tags + GitHub releases.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Tuntii' }}
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native database client libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libmariadb-dev libmariadb-dev-compat libpq-dev libsqlite3-dev
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same crates.io token the Publish workflow uses; expose as CARGO_REGISTRY_TOKEN for release-plz.
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CRATES_IO_TOKEN }}
+
+  # Open/update a PR that bumps versions for the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Tuntii' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-11
+
+First **semantic release** after dropping commit-count versioning (`0.1.<n>`). Workspace crates stay on a single version group; future bumps come from conventional commits via [release-plz](https://release-plz.dev).
+
 ### Added
 
 - **MCP HTTP admin token enforcement**: when `McpConfig::admin_token` is set, the sidecar rejects unauthenticated JSON-RPC with `401` (`Authorization: Bearer`, `X-MCP-Token`, or `?token=`).
@@ -15,13 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cargo rustapi new`**: `protocol-mcp` feature option; `ai-api` preset includes it; minimal template wires `McpServer` + `RUSTAPI_MCP_TOKEN` when selected.
 - **`docs/GOLDEN_PATH.md`** — canonical handler → OpenAPI → probes → MCP/deploy walkthrough; linked from README, docs hub, cookbook SUMMARY, Getting Started.
 - **`golden_path` example** uses route macros + tags so `/docs/openapi.json` includes `/api/v1/ping` (not only `.route()` wiring).
+- **`cargo rustapi generate crud`**: SQLx-sqlite-backed list/get/create/update/delete handlers with schema bootstrap (`src/db.rs`) instead of `TODO` stubs.
+- **`file_upload` example** (`crates/rustapi-rs/examples/file_upload.rs`) demonstrating multipart uploads with the public `rustapi_rs::prelude` API.
+- **Slim vs full dependency guidance** in [Getting Started](docs/GETTING_STARTED.md).
+- **release-plz** CI: conventional-commit version bumps, release PRs, tags, GitHub releases, and crates.io publish for the workspace version group.
 
 ### Changed
 
-- **Dependabot consolidation**: lockfile bumps for `open` 5.4.0, `toml` 1.1.3, `uuid` 1.23.5, `http-body-util` 0.1.4, `bytes` 1.12.1, `simd-json` 0.17.3, `regex` 1.13.0, `rustls` 0.23.42, `redis` 1.4.0 (supersedes open Dependabot PRs #228–#236; skips major `rand` 0.8→0.10).
-- **Production Readiness v0.2** ([#200](https://github.com/Tuntii/RustAPI/issues/200)): coverage CI publishes HTML + Cobertura artifacts with job summary; release-drafter publishes drafts on `v*` tags; README links [Production Checklist](docs/PRODUCTION_CHECKLIST.md) in the header.
+- **Versioning policy**: stop using git commit count (`0.1.<commit>`); use SemVer (feat → minor, fix → patch, `BREAKING CHANGE` / `!` → major within `0.x` rules via release-plz).
+- **Dependabot consolidation**: lockfile bumps for `open`, `toml`, `uuid`, `http-body-util`, `bytes`, `simd-json`, `regex`, `rustls`, `redis` (and a full maintenance `cargo update` pass for 0.2.0).
+- **Production Readiness v0.2** ([#200](https://github.com/Tuntii/RustAPI/issues/200)): coverage CI publishes HTML + Cobertura artifacts with job summary; release-drafter on `v*` tags; README links [Production Checklist](docs/PRODUCTION_CHECKLIST.md) in the header.
 - README Quick Start: golden path first; document OpenAPI at `/docs/openapi.json`; prefer macros for OpenAPI registration; `tracing-subscriber` + `production_defaults` in the hello snippet.
-- Dependency updates: `actions/checkout@v7`, `actions/cache@v6`, `brotli` 8, `rcgen` 0.14, `tera` 2, `thiserror` 2, OpenTelemetry 0.32 stack, `sqlx` 0.9, `tracing-opentelemetry` 0.33.
+- Dependency updates: `actions/checkout@v7`, `actions/cache@v6`, `brotli` 8, `rcgen` 0.14, `tera` 2, `thiserror` 2, OpenTelemetry 0.32 stack, `sqlx` 0.9, `tracing-opentelemetry` 0.33, `tokio` 1.53.
 - Default `rustapi-rs` dependency tree slimmed from ~259 to ~158 transitive crates by removing always-on `tracing-subscriber` and gating `rust-i18n` behind the `i18n` feature (English fallbacks by default).
 - `RustApi::new()` no longer auto-initializes `tracing-subscriber`; initialize tracing in `main` (CLI templates already do).
 - Removed unused `screenshots` / `image` / `base64` dev-dependencies that pulled vulnerable `quick-xml` transitives into `cargo audit`.
@@ -35,19 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SQLx 0.9 jobs + CRUD generator**: Postgres job backend uses `AssertSqlSafe` and `Json` payloads; `cargo rustapi generate crud` emits SQLx 0.9-compatible SQLite handlers.
 - **Security Audit** (`cargo audit`) passes on the current lockfile (no high-severity `quick-xml` advisories).
 
-## [0.1.551] - 2026-07-05
-
-### Added
-
-- **`cargo rustapi generate crud`**: SQLx-sqlite-backed list/get/create/update/delete handlers with schema bootstrap (`src/db.rs`) instead of `TODO` stubs.
-- **`file_upload` example** (`crates/rustapi-rs/examples/file_upload.rs`) demonstrating multipart uploads with the public `rustapi_rs::prelude` API.
-- **Slim vs full dependency guidance** in [Getting Started](docs/GETTING_STARTED.md).
-
 ### Documentation
 
 - Refreshed [Performance Benchmarks](docs/PERFORMANCE_BENCHMARKS.md) with a new `perf_snapshot` run.
 - Updated [file uploads cookbook](docs/cookbook/src/recipes/file_uploads.md) to use `BodyLimitLayer` and `rustapi_rs::prelude` imports.
-- Version strings aligned to **0.1.551** across user-facing READMEs and install docs.
+- Version strings aligned to **0.2.0** across user-facing READMEs and install docs.
+
+## [0.1.551] - 2026-07-05
+
+Workspace/docs-only maturity sprint (CRUD generator, file upload example). Not published to crates.io; content is included in **0.2.0**.
 
 ## [0.1.550] - 2026-06-25
 
@@ -614,7 +619,8 @@ This release delivers a **12x performance improvement**, bringing RustAPI from ~
 - `extras` meta-feature for common optional features
 - `full` feature for all optional features
 
-[Unreleased]: https://github.com/Tuntii/RustAPI/compare/v0.1.551...HEAD
+[Unreleased]: https://github.com/Tuntii/RustAPI/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Tuntii/RustAPI/compare/v0.1.550...v0.2.0
 [0.1.551]: https://github.com/Tuntii/RustAPI/compare/v0.1.550...v0.1.551
 [0.1.550]: https://github.com/Tuntii/RustAPI/compare/v0.1.537...v0.1.550
 [0.1.537]: https://github.com/Tuntii/RustAPI/compare/v0.1.528...v0.1.537

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -449,23 +449,32 @@ rustapi-rs (public API)
 
 ### Versioning
 
-RustAPI follows [Semantic Versioning](https://semver.org/):
+RustAPI follows [Semantic Versioning](https://semver.org/) driven by **conventional commits** (from **v0.2.0**). We do **not** use git commit count for versions.
 
-- **MAJOR** (0.x.0) - Breaking changes
-- **MINOR** (0.1.x) - New features, backwards compatible
-- **PATCH** (0.1.x) - Bug fixes, backwards compatible
+| Commit type | Bump |
+|-------------|------|
+| `feat:` | minor |
+| `fix:`, `chore:`, `docs:`, … | patch |
+| `BREAKING CHANGE` / `type!:` | major |
+
+Automation: **release-plz** (see `release-plz.toml` and `.github/workflows/release-plz.yml`). Prefer squash-merge titles that stay conventional (`feat: …`, `fix: …`).
 
 ### Release Checklist (Maintainers)
 
-1. Update version in `Cargo.toml` (workspace.package.version)
-2. Update all crate references to new version
-3. Update CHANGELOG.md with release notes
-4. Run full test suite: `cargo test --workspace --all-features`
-5. Build documentation: `cargo doc --workspace --all-features`
-6. Tag release: `git tag v0.1.x`
-7. Push tag: `git push origin v0.1.x`
-8. Publish crates: `./scripts/publish.ps1` or `./scripts/smart_publish.ps1`
-9. Create GitHub release with changelog
+**Preferred (automated):**
+
+1. Keep `CHANGELOG.md` **Unreleased** section accurate as PRs land.
+2. Merge work to `main` with conventional commit messages.
+3. Merge the release-plz PR when CI is green (it bumps workspace versions).
+4. release-plz tags `vX.Y.Z`, opens the GitHub release, and publishes to crates.io (`CARGO_REGISTRY_TOKEN` secret required).
+5. Optionally refresh `RELEASES.md` for major stories.
+
+**Manual fallback:**
+
+1. Bump `[workspace.package].version` and path-dep versions in root `Cargo.toml`
+2. Move **Unreleased** → dated section in `CHANGELOG.md`; update docs version pins if needed
+3. `cargo test --workspace` (and `--all-features` when DB libs are available)
+4. Tag `vX.Y.Z`, push tag, run Publish workflow or `scripts/smart_publish.ps1`
 
 ## Documentation Contributions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -40,9 +40,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -94,14 +94,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -130,7 +130,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -142,7 +142,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -154,7 +154,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -202,18 +202,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -348,9 +348,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -425,7 +425,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-rustapi"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -446,7 +446,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -472,9 +472,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -525,14 +525,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -577,15 +577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,9 +609,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -686,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -705,24 +696,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -777,7 +768,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -791,7 +782,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -802,7 +793,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -813,7 +804,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -832,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der-parser"
@@ -871,11 +862,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.10"
+version = "2.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "diesel_derives",
  "downcast-rs",
@@ -900,7 +891,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -909,7 +900,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -925,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
 ]
 
 [[package]]
@@ -942,13 +933,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -980,7 +971,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -991,9 +982,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -1035,7 +1026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1050,11 +1041,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1083,15 +1073,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1161,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1176,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1186,15 +1176,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1214,38 +1204,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1260,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1309,15 +1299,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1458,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1468,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1503,18 +1493,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1719,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1758,29 +1748,29 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -1843,7 +1833,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1858,7 +1848,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1877,24 +1867,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1919,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1933,7 +1923,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -1945,9 +1935,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1957,9 +1947,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1968,22 +1958,22 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2052,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -2090,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2159,7 +2149,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2189,7 +2179,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2198,7 +2188,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2258,9 +2248,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2282,7 +2272,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2312,7 +2302,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2344,8 +2334,8 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2412,7 +2402,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2429,9 +2419,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
@@ -2504,7 +2494,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2526,14 +2516,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2549,7 +2539,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2560,9 +2550,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2591,7 +2581,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2615,7 +2605,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2639,7 +2629,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2656,14 +2646,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2693,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2704,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2787,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "pem",
  "ring",
@@ -2801,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb5358643f48330db5c78856982faf39c93ba50c60d682b43d0344a3b649769"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -2829,34 +2819,34 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2866,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2975,7 +2965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3006,7 +2996,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3034,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-core"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3079,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-extras"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -3101,7 +3091,7 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "r2d2",
- "rand 0.8.6",
+ "rand 0.8.7",
  "redis",
  "reqwest 0.12.28",
  "rustapi-core",
@@ -3123,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-grpc"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "prost",
  "rustapi-core",
@@ -3134,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-macros"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3142,12 +3132,12 @@ dependencies = [
  "rustapi-rs",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "rustapi-mcp"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3161,7 +3151,7 @@ dependencies = [
  "rustapi-rs",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -3169,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-openapi"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "http",
@@ -3181,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-rs"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3209,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-testing"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "http",
@@ -3226,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-toon"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "futures-util",
@@ -3243,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-validate"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "http",
@@ -3259,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-view"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "http",
@@ -3275,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "rustapi-ws"
-version = "0.1.551"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3290,7 +3280,7 @@ dependencies = [
  "rustapi-openapi",
  "serde",
  "serde_json",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -3328,18 +3318,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3363,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3389,7 +3379,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3400,9 +3390,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3411,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3472,7 +3462,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3497,9 +3487,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3507,29 +3497,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3604,14 +3594,14 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3699,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd-json"
@@ -3719,9 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -3756,12 +3746,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3827,7 +3817,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3846,7 +3836,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3869,7 +3859,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -3880,7 +3870,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -3897,7 +3887,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
 ]
@@ -3910,7 +3900,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -3933,7 +3923,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
  "whoami",
@@ -3959,7 +3949,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "url",
  "uuid",
@@ -3996,9 +3986,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4022,7 +4023,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4035,14 +4036,14 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tera"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
+checksum = "638c0720e7c1f61722366256d369ea46139634e77738735d6d9bb287bbbad35f"
 dependencies = [
  "globset",
  "serde",
@@ -4066,11 +4067,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4081,34 +4082,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4126,9 +4127,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4146,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4161,9 +4162,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4177,13 +4178,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4198,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4222,13 +4223,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4247,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4257,7 +4259,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4294,23 +4296,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4387,7 +4389,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4415,7 +4417,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -4459,7 +4461,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4546,8 +4548,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
- "sha1 0.10.6",
+ "rand 0.8.7",
+ "sha1 0.10.7",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -4665,9 +4667,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4702,7 +4704,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4713,9 +4715,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -4780,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4793,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4803,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4813,22 +4815,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4848,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4868,18 +4870,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4896,7 +4898,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4920,7 +4922,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4931,7 +4933,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5134,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5167,15 +5169,15 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yasna"
@@ -5206,28 +5208,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5247,7 +5249,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5268,7 +5270,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5301,11 +5303,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 exclude = ["apps/bayram-leaderboard"]
 
 [workspace.package]
-version = "0.1.551"
+version = "0.2.0"
 edition = "2021"
 authors = ["RustAPI Contributors, Tuntii"]
 license = "MIT OR Apache-2.0"
@@ -96,18 +96,18 @@ open = "5"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Internal crates
-rustapi-rs = { path = "crates/rustapi-rs", version = "0.1.551", default-features = false }
-rustapi-core = { path = "crates/rustapi-core", version = "0.1.551", default-features = false }
-rustapi-macros = { path = "crates/rustapi-macros", version = "0.1.551" }
-rustapi-validate = { path = "crates/rustapi-validate", version = "0.1.551" }
-rustapi-openapi = { path = "crates/rustapi-openapi", version = "0.1.551", default-features = false }
-rustapi-extras = { path = "crates/rustapi-extras", version = "0.1.551" }
-rustapi-toon = { path = "crates/rustapi-toon", version = "0.1.551" }
-rustapi-ws = { path = "crates/rustapi-ws", version = "0.1.551" }
-rustapi-view = { path = "crates/rustapi-view", version = "0.1.551" }
-rustapi-testing = { path = "crates/rustapi-testing", version = "0.1.551" }
-rustapi-grpc = { path = "crates/rustapi-grpc", version = "0.1.551" }
-rustapi-mcp = { path = "crates/rustapi-mcp", version = "0.1.551" }
+rustapi-rs = { path = "crates/rustapi-rs", version = "0.2.0", default-features = false }
+rustapi-core = { path = "crates/rustapi-core", version = "0.2.0", default-features = false }
+rustapi-macros = { path = "crates/rustapi-macros", version = "0.2.0" }
+rustapi-validate = { path = "crates/rustapi-validate", version = "0.2.0" }
+rustapi-openapi = { path = "crates/rustapi-openapi", version = "0.2.0", default-features = false }
+rustapi-extras = { path = "crates/rustapi-extras", version = "0.2.0" }
+rustapi-toon = { path = "crates/rustapi-toon", version = "0.2.0" }
+rustapi-ws = { path = "crates/rustapi-ws", version = "0.2.0" }
+rustapi-view = { path = "crates/rustapi-view", version = "0.2.0" }
+rustapi-testing = { path = "crates/rustapi-testing", version = "0.2.0" }
+rustapi-grpc = { path = "crates/rustapi-grpc", version = "0.2.0" }
+rustapi-mcp = { path = "crates/rustapi-mcp", version = "0.2.0" }
 
 # HTTP/3 (QUIC)
 quinn = "0.11"

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Prefer the **[Golden Path](docs/GOLDEN_PATH.md)** for the recommended service sh
 
 ```toml
 [dependencies]
-api = { package = "rustapi-rs", version = "0.1.551" }
+api = { package = "rustapi-rs", version = "0.2.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```
@@ -285,13 +285,13 @@ Full guide: [docs/cookbook/src/recipes/rustapi_cloud.md](docs/cookbook/src/recip
 
 ## Recent Changes
 
-See [CHANGELOG.md](CHANGELOG.md) for full history. Highlights in **v0.1.551**:
+See [CHANGELOG.md](CHANGELOG.md) for full history. Highlights in **v0.2.0** (first semantic release):
 
-- **RustAPI Cloud CLI:** `deploy cloud`, `deploy status`, device-code `login`, `RUSTAPI_CONFIG_PATH` for isolated credentials
-- **Repo split:** cloud backend moved to [RustAPI-Cloud](https://github.com/Tuntii/RustAPI-Cloud); this repo is framework + CLI only
-- **OpenAPI modifiers:** `Multipart` / `Headers` `OperationModifier` for deploy and upload routes
-- **v0.1.537 maintainability:** `builder.rs` module split (#201), consistent `on_shutdown` across all `run*` entrypoints
-- **Native MCP:** in-process tools, `cargo rustapi mcp generate`, stdio transport
+- **Semantic versioning:** drop commit-count `0.1.<n>`; conventional commits + [release-plz](https://release-plz.dev) drive minor/patch/major
+- **MCP hardening:** HTTP admin token enforcement, query-arg tools, `cargo rustapi new` + `protocol-mcp` / `ai-api` templates
+- **Golden path:** [docs/GOLDEN_PATH.md](docs/GOLDEN_PATH.md), OpenAPI-aware `golden_path` example, production checklist in the header
+- **CRUD + uploads:** `cargo rustapi generate crud` (SQLx), `file_upload` example
+- **Maintenance:** sqlx 0.9, tera 2, thiserror 2, OpenTelemetry 0.32, security lockfile bumps (`RUSTSEC-2026-0204`)
 
 ## Documentation
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,34 @@
+# RustAPI v0.2.0 Release Notes
+
+**Release Date**: August 11, 2026  
+**Full Changelog**: https://github.com/Tuntii/RustAPI/compare/v0.1.550...v0.2.0
+
+---
+
+## Highlights
+
+**v0.2.0 is the first semantic release.** We leave commit-count versioning (`0.1.<n>`) behind. From here, versions move with conventional commits and [release-plz](https://release-plz.dev) (release PR → merge → tag + crates.io).
+
+| Area | Change |
+|------|--------|
+| Versioning | SemVer workspace group; `feat` → minor, `fix`/`chore` → patch |
+| MCP | Admin token on HTTP sidecar; query tool args; CLI templates for `protocol-mcp` |
+| DX | Golden path doc + example; production checklist; CRUD generator; file upload example |
+| Deps / security | sqlx 0.9, tera 2, thiserror 2, OTEL 0.32, `RUSTSEC-2026-0204` lockfile fix |
+| CI | release-plz workflow; coverage artifacts; Dependabot-friendly clippy |
+
+**Install:**
+
+```bash
+cargo add rustapi-rs@0.2.0
+# or
+cargo install cargo-rustapi
+```
+
+**Note:** Workspace was at `0.1.551` in-tree without a crates.io publish; that work ships as part of **0.2.0**.
+
+---
+
 # RustAPI v0.1.550 + RustAPI Cloud v0.1.1 Release Notes
 
 **Release Date**: June 25, 2026

--- a/crates/cargo-rustapi/README.md
+++ b/crates/cargo-rustapi/README.md
@@ -114,5 +114,5 @@ Cloud HTTP commands are enabled by default. Disable with:
 
 ```toml
 [dependencies]
-cargo-rustapi = { version = "0.1.551", default-features = false }
+cargo-rustapi = { version = "0.2.0", default-features = false }
 ```

--- a/crates/rustapi-rs/README.md
+++ b/crates/rustapi-rs/README.md
@@ -48,7 +48,7 @@ Feature taxonomy on the facade:
 
 ```toml
 [dependencies]
-api = { package = "rustapi-rs", version = "0.1.551" }
+api = { package = "rustapi-rs", version = "0.2.0" }
 ```
 
 Sonra kodunda:
@@ -71,7 +71,7 @@ Eğer istersen direkt uzun isimle de kullanabilirsin:
 
 ```toml
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 ```
 
 ```rust

--- a/docs/COMMUNITY.html
+++ b/docs/COMMUNITY.html
@@ -252,7 +252,7 @@
 <li><strong>Respectful collaboration</strong> — see the Code of Conduct</li>
 </ul>
 <h2 id="releases"><a class="header" href="#releases">Releases</a></h2>
-<p>Releases are tagged <code>v0.1.&lt;commit-count&gt;</code> and published to <a href="https://crates.io/crates/rustapi-rs">crates.io</a>. See <a href="../CHANGELOG.html">CHANGELOG.md</a> and <a href="../RELEASES.html">RELEASES.md</a> for notes.</p>
+<p>Releases follow <strong>SemVer</strong> from conventional commits (release-plz). Tags look like <code>v0.2.0</code> and publish to <a href="https://crates.io/crates/rustapi-rs">crates.io</a>. See <a href="../CHANGELOG.html">CHANGELOG.md</a> and <a href="../RELEASES.html">RELEASES.md</a> for notes.</p>
 <p><strong>Repository split:</strong> RustAPI Cloud backend development happens in <a href="https://github.com/Tuntii/RustAPI-Cloud">RustAPI-Cloud</a>. This repo ships the framework and CLI only.</p>
 <h2 id="security"><a class="header" href="#security">Security</a></h2>
 <p>Report vulnerabilities privately per <a href="../SECURITY.html">SECURITY.md</a>. Do not open public issues for undisclosed security problems.</p>

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -68,7 +68,7 @@ See [CONTRACT.md](../CONTRACT.md) for stability rules.
 
 ## Releases
 
-Releases are tagged `v0.1.<commit-count>` and published to [crates.io](https://crates.io/crates/rustapi-rs). See [CHANGELOG.md](../CHANGELOG.md) and [RELEASES.md](../RELEASES.md) for notes.
+Releases follow **SemVer** from conventional commits (release-plz). Tags look like `v0.2.0` and publish to [crates.io](https://crates.io/crates/rustapi-rs). See [CHANGELOG.md](../CHANGELOG.md) and [RELEASES.md](../RELEASES.md) for notes.
 
 **Repository split:** RustAPI Cloud backend development happens in [RustAPI-Cloud](https://github.com/Tuntii/RustAPI-Cloud). This repo ships the framework and CLI only.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1159,7 +1159,7 @@ RustApi::new()
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 ```
 
 | Feature | Description |
@@ -1290,7 +1290,7 @@ let events = store.query()
 ### 1. Use `core-simd-json` (when available)
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["core-simd-json"] }
+rustapi-rs = { version = "0.2.0", features = ["core-simd-json"] }
 ```
 
 2-4x faster JSON parsing.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,21 +31,21 @@ Add RustAPI to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 ```
 
 You can also rename the crate if you prefer shorter macro paths:
 
 ```toml
 [dependencies]
-api = { package = "rustapi-rs", version = "0.1.551" }
+api = { package = "rustapi-rs", version = "0.2.0" }
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["extras-jwt", "extras-cors", "protocol-toon", "protocol-ws", "protocol-view"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-jwt", "extras-cors", "protocol-toon", "protocol-ws", "protocol-view"] }
 ```
 
 ### Available Features
@@ -73,7 +73,7 @@ Most production APIs should start **slim** and opt into extras only when needed:
 ```toml
 # Recommended default — fast compiles, ~158 transitive crates
 [dependencies]
-rustapi-rs = { version = "0.1.551", default-features = false, features = ["core"] }
+rustapi-rs = { version = "0.2.0", default-features = false, features = ["core"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```
@@ -83,7 +83,7 @@ Add features incrementally (`extras-jwt`, `extras-cors`, `protocol-ws`, …) ins
 ```toml
 # Kitchen-sink profile — tutorials and exploration only (~900+ transitive crates)
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 ```
 
 | Profile | Transitive crates (approx.) | Compile time | When to use |
@@ -92,7 +92,7 @@ rustapi-rs = { version = "0.1.551", features = ["full"] }
 | `core` + selected `extras-*` / `protocol-*` | ~200–400 | Moderate | Real services with JWT, CORS, SQLx, etc. |
 | `full` | ~900+ | Slowest | Demos, feature discovery, integration tests |
 
-Since **v0.1.551**, `tracing-subscriber` and `rust-i18n` are no longer pulled unconditionally — initialize tracing in `main`, and enable `features = ["i18n"]` when you need Turkish/other validation locales.
+Since **v0.2.0**, `tracing-subscriber` and `rust-i18n` are no longer pulled unconditionally — initialize tracing in `main`, and enable `features = ["i18n"]` when you need Turkish/other validation locales.
 
 ---
 
@@ -408,7 +408,7 @@ ApiError::internal("message")         // 500
 ### CORS
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["extras-cors"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-cors"] }
 ```
 
 ```rust
@@ -429,7 +429,7 @@ RustApi::new()
 ### JWT Authentication
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["extras-jwt"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-jwt"] }
 ```
 
 ```rust
@@ -458,7 +458,7 @@ async fn protected(user: AuthUser<Claims>) -> Json<Response> {
 ### Rate Limiting
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["extras-rate-limit"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-rate-limit"] }
 ```
 
 ```rust
@@ -476,7 +476,7 @@ RustApi::new()
 ## TOON Format (LLM Optimization)
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["protocol-toon"] }
+rustapi-rs = { version = "0.2.0", features = ["protocol-toon"] }
 ```
 
 ```rust
@@ -507,7 +507,7 @@ Response includes token counting headers:
 Real-time bidirectional communication:
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["protocol-ws"] }
+rustapi-rs = { version = "0.2.0", features = ["protocol-ws"] }
 ```
 
 ```rust
@@ -544,7 +544,7 @@ websocat ws://localhost:8080/ws
 Server-side HTML rendering with Tera:
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["protocol-view"] }
+rustapi-rs = { version = "0.2.0", features = ["protocol-view"] }
 ```
 
 Create a template file `templates/index.html`:
@@ -801,7 +801,7 @@ struct AnyBody { ... }
 Check that `core-openapi` is enabled (it is included in the default `core` feature):
 
 ```toml
-rustapi-rs = { version = "0.1.551", features = ["core-openapi"] }
+rustapi-rs = { version = "0.2.0", features = ["core-openapi"] }
 ```
 
 ### CLI Commands Not Working

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -72,7 +72,7 @@ We achieve this through:
 ```toml
 # Your Cargo.toml - simple and stable
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 ```
 
 You never write:
@@ -111,13 +111,13 @@ validator = "0.16"
 
 ```toml
 # Just the basics
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 
 # Kitchen sink
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 
 # Pick what you need
-rustapi-rs = { version = "0.1.551", features = ["extras-jwt", "extras-cors", "protocol-toon"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-jwt", "extras-cors", "protocol-toon"] }
 ```
 
 | Feature | What You Get |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Central index for user guides, architecture notes, and open-source contribution paths.
 
-**Current release:** [`rustapi-rs` 0.1.551](https://crates.io/crates/rustapi-rs) · [Changelog](../CHANGELOG.md) · [All releases](https://github.com/Tuntii/RustAPI/releases)
+**Current release:** [`rustapi-rs` 0.2.0](https://crates.io/crates/rustapi-rs) · [Changelog](../CHANGELOG.md) · [All releases](https://github.com/Tuntii/RustAPI/releases)
 
 ---
 
@@ -64,14 +64,14 @@ Central index for user guides, architecture notes, and open-source contribution 
 
 ```toml
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 ```
 
 Alias for shorter macros (recommended):
 
 ```toml
 [dependencies]
-api = { package = "rustapi-rs", version = "0.1.551" }
+api = { package = "rustapi-rs", version = "0.2.0" }
 ```
 
 ```rust

--- a/docs/cookbook/src/crates/cargo_rustapi.md
+++ b/docs/cookbook/src/crates/cargo_rustapi.md
@@ -143,7 +143,7 @@ Cloud commands require the `cloud` feature (default-on):
 
 ```toml
 [dependencies]
-cargo-rustapi = { version = "0.1.551", default-features = false }
+cargo-rustapi = { version = "0.2.0", default-features = false }
 ```
 
 Disabling removes `login`, `deploy cloud`, and `deploy status` — useful for minimal CI builds.

--- a/docs/cookbook/src/crates/rustapi_extras.md
+++ b/docs/cookbook/src/crates/rustapi_extras.md
@@ -93,7 +93,7 @@ The `insight` feature provides powerful real-time traffic analysis and debugging
 
 ```toml
 [dependencies]
-rustapi-extras = { version = "0.1.551", features = ["insight"] }
+rustapi-extras = { version = "0.2.0", features = ["insight"] }
 ```
 
 ### Setup

--- a/docs/cookbook/src/crates/rustapi_grpc.md
+++ b/docs/cookbook/src/crates/rustapi_grpc.md
@@ -16,7 +16,7 @@
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["grpc"] }
+rustapi-rs = { version = "0.2.0", features = ["grpc"] }
 ```
 
 ## Basic Usage

--- a/docs/cookbook/src/crates/rustapi_jobs.md
+++ b/docs/cookbook/src/crates/rustapi_jobs.md
@@ -107,7 +107,7 @@ Enable the `redis` feature in `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-jobs = { version = "0.1.551", features = ["redis"] }
+rustapi-jobs = { version = "0.2.0", features = ["redis"] }
 ```
 
 ```rust
@@ -123,7 +123,7 @@ Enable the `postgres` feature in `Cargo.toml`. This uses `sqlx`.
 
 ```toml
 [dependencies]
-rustapi-jobs = { version = "0.1.551", features = ["postgres"] }
+rustapi-jobs = { version = "0.2.0", features = ["postgres"] }
 ```
 
 ```rust

--- a/docs/cookbook/src/crates/rustapi_mcp.md
+++ b/docs/cookbook/src/crates/rustapi_mcp.md
@@ -18,7 +18,7 @@
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["protocol-mcp"] }
+rustapi-rs = { version = "0.2.0", features = ["protocol-mcp"] }
 ```
 
 ## Basic Usage (Recommended)

--- a/docs/cookbook/src/getting_started/installation.md
+++ b/docs/cookbook/src/getting_started/installation.md
@@ -30,14 +30,14 @@ cargo-rustapi --version
 If you prefer not to use the CLI, you can add RustAPI to your `Cargo.toml` manually:
 
 ```bash
-cargo add rustapi-rs@0.1.551
+cargo add rustapi-rs@0.2.0
 ```
 
 Or add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 ```
 
 ## Editor Setup

--- a/docs/cookbook/src/recipes/advanced_middleware.md
+++ b/docs/cookbook/src/recipes/advanced_middleware.md
@@ -10,9 +10,9 @@ Add the `rustapi-extras` crate with the necessary features to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 # OR cherry-pick features
-# rustapi-extras = { version = "0.1.551", features = ["rate-limit", "dedup", "cache"] }
+# rustapi-extras = { version = "0.2.0", features = ["rate-limit", "dedup", "cache"] }
 ```
 
 ## Rate Limiting

--- a/docs/cookbook/src/recipes/ai_integration.md
+++ b/docs/cookbook/src/recipes/ai_integration.md
@@ -34,7 +34,7 @@ This is handled automatically by the `LlmResponse<T>` type.
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["toon"] }
+rustapi-rs = { version = "0.2.0", features = ["toon"] }
 serde = { version = "1.0", features = ["derive"] }
 ```
 

--- a/docs/cookbook/src/recipes/audit_logging.md
+++ b/docs/cookbook/src/recipes/audit_logging.md
@@ -10,7 +10,7 @@ Add `rustapi-extras` with the `audit` feature to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-rustapi-extras = { version = "0.1.551", features = ["audit"] }
+rustapi-extras = { version = "0.2.0", features = ["audit"] }
 ```
 
 ## Core Concepts

--- a/docs/cookbook/src/recipes/compression.md
+++ b/docs/cookbook/src/recipes/compression.md
@@ -8,7 +8,7 @@ To use compression, you must enable the `compression` feature in `rustapi-core` 
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["compression", "compression-brotli"] }
+rustapi-rs = { version = "0.2.0", features = ["compression", "compression-brotli"] }
 ```
 
 ## Basic Usage

--- a/docs/cookbook/src/recipes/csrf_protection.md
+++ b/docs/cookbook/src/recipes/csrf_protection.md
@@ -15,7 +15,7 @@ RustAPI's CSRF protection works by:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["csrf"] }
+rustapi-rs = { version = "0.2.0", features = ["csrf"] }
 ```
 
 ```rust

--- a/docs/cookbook/src/recipes/dashboard.md
+++ b/docs/cookbook/src/recipes/dashboard.md
@@ -13,14 +13,14 @@ Enable the canonical dashboard feature on the public facade:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["core-dashboard"] }
+rustapi-rs = { version = "0.2.0", features = ["core-dashboard"] }
 ```
 
 If you also want the replay browser panel to load recorded traffic, enable replay too:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["core-dashboard", "extras-replay"] }
+rustapi-rs = { version = "0.2.0", features = ["core-dashboard", "extras-replay"] }
 ```
 
 ## Usage

--- a/docs/cookbook/src/recipes/db_integration.md
+++ b/docs/cookbook/src/recipes/db_integration.md
@@ -8,7 +8,7 @@ This recipe shows how to integrate PostgreSQL/MySQL/SQLite using a shared pool, 
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["extras-sqlx"] } # Canonical facade feature for SQLx error conversion
+rustapi-rs = { version = "0.2.0", features = ["extras-sqlx"] } # Canonical facade feature for SQLx error conversion
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/docs/cookbook/src/recipes/file_uploads.md
+++ b/docs/cookbook/src/recipes/file_uploads.md
@@ -13,7 +13,7 @@ curl -X POST http://127.0.0.1:8080/upload -F "file=@./README.md"
 
 ```toml
 [dependencies]
-rustapi-rs = "0.1.551"
+rustapi-rs = "0.2.0"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 ```
 

--- a/docs/cookbook/src/recipes/grpc_integration.md
+++ b/docs/cookbook/src/recipes/grpc_integration.md
@@ -8,7 +8,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["grpc"] }
+rustapi-rs = { version = "0.2.0", features = ["grpc"] }
 tonic = "0.10"
 prost = "0.12"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/docs/cookbook/src/recipes/http3_quic.md
+++ b/docs/cookbook/src/recipes/http3_quic.md
@@ -8,9 +8,9 @@ HTTP/3 support is optional and can be enabled via feature flags in `Cargo.toml`.
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["http3"] }
+rustapi-rs = { version = "0.2.0", features = ["http3"] }
 # For development with self-signed certificates
-rustapi-rs = { version = "0.1.551", features = ["http3", "http3-dev"] }
+rustapi-rs = { version = "0.2.0", features = ["http3", "http3-dev"] }
 ```
 
 ## Running an HTTP/3 Server

--- a/docs/cookbook/src/recipes/jwt_auth.md
+++ b/docs/cookbook/src/recipes/jwt_auth.md
@@ -8,7 +8,7 @@ Enable the `extras-jwt` feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["extras-jwt"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-jwt"] }
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/docs/cookbook/src/recipes/observability.md
+++ b/docs/cookbook/src/recipes/observability.md
@@ -19,7 +19,7 @@ Enable the relevant features:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = [
+rustapi-rs = { version = "0.2.0", features = [
   "core",
   "extras-otel",
   "extras-structured-logging",

--- a/docs/cookbook/src/recipes/replay.md
+++ b/docs/cookbook/src/recipes/replay.md
@@ -20,7 +20,7 @@ Enable the canonical replay feature in your application:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["extras-replay"] }
+rustapi-rs = { version = "0.2.0", features = ["extras-replay"] }
 ```
 
 On the CLI side, `cargo-rustapi` is enough; replay commands are part of the default installation:

--- a/docs/cookbook/src/recipes/resilience.md
+++ b/docs/cookbook/src/recipes/resilience.md
@@ -10,9 +10,9 @@ Add the resilience features to your `Cargo.toml`. For example:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 # OR cherry-pick features
-# rustapi-extras = { version = "0.1.551", features = ["circuit-breaker", "retry", "timeout"] }
+# rustapi-extras = { version = "0.2.0", features = ["circuit-breaker", "retry", "timeout"] }
 ```
 
 ## Circuit Breaker

--- a/docs/cookbook/src/recipes/rustapi_cloud.md
+++ b/docs/cookbook/src/recipes/rustapi_cloud.md
@@ -163,7 +163,7 @@ Cloud HTTP commands are gated behind the `cloud` feature on `cargo-rustapi` (ena
 ```toml
 # Cargo.toml — disable cloud commands
 [dependencies]
-cargo-rustapi = { version = "0.1.551", default-features = false }
+cargo-rustapi = { version = "0.2.0", default-features = false }
 ```
 
 When disabled, `login`, `deploy cloud`, and `deploy status` are not compiled. Workspace builds with `--no-default-features` remain supported.

--- a/docs/cookbook/src/recipes/server_side_rendering.md
+++ b/docs/cookbook/src/recipes/server_side_rendering.md
@@ -8,7 +8,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["view"] }
+rustapi-rs = { version = "0.2.0", features = ["view"] }
 serde = { version = "1.0", features = ["derive"] }
 ```
 

--- a/docs/cookbook/src/recipes/testing.md
+++ b/docs/cookbook/src/recipes/testing.md
@@ -8,7 +8,7 @@ Add `rustapi-testing` to your `Cargo.toml`. It is usually added as a dev-depende
 
 ```toml
 [dev-dependencies]
-rustapi-testing = "0.1.551"
+rustapi-testing = "0.2.0"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/cookbook/src/recipes/websockets.md
+++ b/docs/cookbook/src/recipes/websockets.md
@@ -6,7 +6,7 @@ WebSockets allow full-duplex communication between the client and server. RustAP
 
 ```toml
 [dependencies]
-rustapi-ws = "0.1.551"
+rustapi-ws = "0.2.0"
 tokio = { version = "1", features = ["sync", "macros"] }
 futures = "0.3"
 ```

--- a/docs/cookbook/src/troubleshooting.md
+++ b/docs/cookbook/src/troubleshooting.md
@@ -47,7 +47,7 @@ utoipa = "4.2"  # âŒ Don't add this
 **Correct:**
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1.551", features = ["full"] }
+rustapi-rs = { version = "0.2.0", features = ["full"] }
 # rustapi-openapi is re-exported through rustapi-rs
 ```
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,91 @@
+# release-plz: semantic releases for the RustAPI workspace
+# Docs: https://release-plz.dev/docs/config
+#
+# All public crates share one version (workspace.package.version).
+# Conventional commits on main → release PR → merge → tag + crates.io.
+
+[workspace]
+# Single version for the framework suite (matches [workspace.package].version).
+features_always_increment_minor = true
+# Keep our hand-written Keep a Changelog file; release-plz still bumps Cargo.toml.
+changelog_update = false
+changelog_path = "CHANGELOG.md"
+dependencies_update = false
+semver_check = false
+repo_url = "https://github.com/Tuntii/RustAPI"
+git_release_enable = true
+git_release_name = "v{{ version }}"
+git_release_body = """
+{{ changelog }}
+
+---
+**Install:** `cargo add rustapi-rs@{{ version }}`  
+**Full notes:** [CHANGELOG.md](https://github.com/Tuntii/RustAPI/blob/main/CHANGELOG.md) · [RELEASES.md](https://github.com/Tuntii/RustAPI/blob/main/RELEASES.md)
+"""
+git_tag_name = "v{{ version }}"
+pr_name = "release: v{{ version }}"
+pr_labels = ["release"]
+pr_branch_prefix = "release-plz-"
+# Publish any unpublished workspace versions on main (version bumps still come from
+# the release PR or an intentional SemVer bump like this 0.2.0 cut).
+release_always = true
+publish_timeout = "30m"
+
+# Shared version group: every publishable crate stays aligned.
+[[package]]
+name = "rustapi-macros"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-validate"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-openapi"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-core"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-testing"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-extras"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-toon"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-ws"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-view"
+version_group = "rustapi"
+
+[[package]]
+name = "rustapi-grpc"
+version_group = "rustapi"
+publish_no_verify = true
+
+[[package]]
+name = "rustapi-mcp"
+version_group = "rustapi"
+publish_no_verify = true
+
+[[package]]
+name = "rustapi-rs"
+version_group = "rustapi"
+# Facade crate drives the public GitHub release notes.
+git_release_enable = true
+
+[[package]]
+name = "cargo-rustapi"
+version_group = "rustapi"
+# Binary crate: still publish; release notes come from the version group.
+git_release_enable = false


### PR DESCRIPTION
## Summary

- **Maintenance**: full `cargo update`, lockfile security fix path (`RUSTSEC-2026-0204` already landed), audit clean (only allowed `proc-macro-error2` unmaintained warning)
- **Version**: `0.1.551` (unpublished) + unreleased work → **`0.2.0`** first SemVer cut after drop of commit-count `0.1.<n>`
- **Semantic release**: [release-plz](https://release-plz.dev) workflow + `release-plz.toml` (shared version group, conventional commits)
- **Docs**: CHANGELOG / RELEASES / CONTRIBUTING / COMMUNITY / install pins → 0.2.0
- **CI**: release-drafter no longer publishes on tags (release-plz owns tags + GitHub releases + crates.io)

## After merge

1. Ensure repo secret **`CARGO_REGISTRY_TOKEN`** or **`CRATES_IO_TOKEN`** is set (release-plz maps either).
2. Allow GitHub Actions to create PRs (Settings → Actions → General → Workflow permissions).
3. On push to `main`, release-plz should publish **0.2.0** (unpublished on crates.io; max is 0.1.550) and tag `v0.2.0`.
4. Fallback: tag `v0.2.0` + run **Publish to crates.io** workflow.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace --lib`
- [x] `cargo audit` (no vulnerabilities; 1 allowed unmaintained warning)
- [ ] CI green on this PR
- [ ] After merge: crates.io shows `rustapi-rs` 0.2.0 and GitHub release `v0.2.0`