### PR TITLE
fix(ci): coverage job — tarpaulin segfault → cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Install native database client libraries
         run: |
@@ -207,39 +209,49 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-coverage-
 
-      - name: Install cargo-tarpaulin
-        uses: taiki-e/install-action@cargo-tarpaulin
+      # tarpaulin's default ptrace engine segfaults under multi-threaded tokio
+      # integration tests on GHA. cargo-llvm-cov uses LLVM instrumentation instead.
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run coverage
         run: |
+          mkdir -p coverage
           # cargo-rustapi spawns nested `cargo` builds in integration tests;
-          # tarpaulin cannot instrument those subprocesses reliably.
-          cargo tarpaulin --workspace \
-            --exclude cargo-rustapi \
-            --timeout 900 \
-            --out Html \
-            --out Xml \
-            --output-dir coverage
+          # those subprocesses are not useful to instrument for line coverage.
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --workspace --exclude cargo-rustapi --no-report
+          cargo llvm-cov report --lcov --output-path coverage/lcov.info
+          cargo llvm-cov report --html --output-dir coverage/html
+          cargo llvm-cov report --cobertura --output-path coverage/cobertura.xml
+          cargo llvm-cov report --summary-only | tee coverage/summary.txt
 
       - name: Upload coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: |
-            coverage/tarpaulin-report.html
+            coverage/html
+            coverage/lcov.info
             coverage/cobertura.xml
+            coverage/summary.txt
+          if-no-files-found: ignore
           retention-days: 30
 
       - name: Coverage summary
+        if: always()
         run: |
-          if [ -f coverage/tarpaulin-report.html ]; then
-            pct=$(grep -oP '(?<=<h1>Tarpaulin coverage report</h1>.*?)[0-9.]+%' coverage/tarpaulin-report.html | head -1 || true)
-            echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
-            echo "Download the **coverage-report** artifact for the full HTML report." >> "$GITHUB_STEP_SUMMARY"
-            if [ -n "$pct" ]; then
-              echo "Line coverage: **${pct}**" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Coverage"
+            echo "Engine: **cargo-llvm-cov** (LLVM). Download the **coverage-report** artifact for HTML/LCOV."
+            echo ""
+            if [ -f coverage/summary.txt ]; then
+              echo '```'
+              cat coverage/summary.txt
+              echo '```'
             fi
-          fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
   [![MSRV](https://img.shields.io/badge/MSRV-1.85-orange)](Cargo.toml)
   [![Security Audit](https://github.com/Tuntii/RustAPI/actions/workflows/audit.yml/badge.svg)](https://github.com/Tuntii/RustAPI/actions/workflows/audit.yml)
-  [![Coverage](https://img.shields.io/badge/coverage-tarpaulin-blue)](https://github.com/Tuntii/RustAPI/actions/workflows/ci.yml)
+  [![Coverage](https://img.shields.io/badge/coverage-llvm--cov-blue)](https://github.com/Tuntii/RustAPI/actions/workflows/ci.yml)
   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Tuntii/RustAPI)
 
 </div>


### PR DESCRIPTION
## Problem
Coverage job fails on main with:
```
ERROR cargo_tarpaulin: Failed to run tests: A segfault occurred while executing tests
```
Reproduced while running `rustapi-rs` `integration_tests` under tarpaulin ptrace.

## Fix
- Install `llvm-tools-preview` + **cargo-llvm-cov**
- Run instrumented tests once, then emit LCOV / HTML / Cobertura + summary
- Still exclude `cargo-rustapi` (nested cargo subprocesses)
- Upload artifacts with `if: always()`

## Test plan
- [ ] Coverage job green on this PR
- [ ] Artifact `coverage-report` contains html + lcov + cobertura
- [ ] Other CI jobs unchanged (Lint/Build/Docs)