### PR TITLE
docs: fix CONTRIBUTING first-run path and rustapi-rs crates.io README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,14 @@ cargo build --workspace --release
 
 ### Running Examples
 
-```bash
-# Run a specific example
-cargo run -p hello-world
+In-repo examples live under `crates/rustapi-rs/examples/`. Start with the golden path (see [docs/GOLDEN_PATH.md](docs/GOLDEN_PATH.md)):
 
-# List all examples
-ls examples/
+```bash
+# First run — handler → OpenAPI → probes
+cargo run -p rustapi-rs --example golden_path
+
+# List in-repo examples
+ls crates/rustapi-rs/examples/
 ```
 
 ## Making Changes
@@ -398,6 +400,7 @@ Closes #456
 RustAPI/
 ├── crates/
 │   ├── rustapi-rs/       # 🎯 Public-facing crate (re-exports)
+│   │   └── examples/     # 📖 In-crate examples (start with golden_path)
 │   ├── rustapi-core/     # ⚙️  Core HTTP engine and routing
 │   ├── rustapi-macros/   # 🔧 Procedural macros (#[get], #[post], etc.)
 │   ├── rustapi-validate/ # ✅ Validation integration (validator crate)
@@ -406,18 +409,12 @@ RustAPI/
 │   ├── rustapi-toon/     # 🎨 TOON format support
 │   ├── rustapi-ws/       # 🔌 WebSocket support
 │   ├── rustapi-view/     # 🖼️  Template rendering (Tera)
+│   ├── rustapi-testing/  # 🧪 Test client and fluent assertions
+│   ├── rustapi-grpc/     # 📡 gRPC helpers (Tonic)
+│   ├── rustapi-mcp/      # 🤖 Native MCP (expose routes as LLM tools)
 │   └── cargo-rustapi/    # 📦 CLI tool
-├── examples/             # 📖 Example applications
-│   ├── hello-world/      # Basic example
-│   ├── crud-api/         # CRUD operations
-│   ├── auth-api/         # Authentication
-│   ├── sqlx-crud/        # Database integration
-│   ├── websocket/        # WebSocket example
-│   └── ...
-├── benches/              # 🏃 Performance benchmarks
 ├── docs/                 # 📝 Documentation
-├── scripts/              # 🛠️  Build and publish scripts
-└── memories/             # 🧠 Project memory/context
+└── scripts/              # 🛠️  Build and publish scripts
 ```
 
 ### Crate Dependencies
@@ -441,7 +438,7 @@ rustapi-rs (public API)
 - **Adding validation** → `rustapi-validate`
 - **Adding OpenAPI features** → `rustapi-openapi`
 - **Adding optional features** → `rustapi-extras`
-- **Adding examples** → `examples/`
+- **Adding examples** → `crates/rustapi-rs/examples/`
 - **Adding tests** → relevant crate's `tests/` directory
 - **Adding docs** → `docs/` or inline rustdoc
 

--- a/crates/rustapi-rs/README.md
+++ b/crates/rustapi-rs/README.md
@@ -44,49 +44,21 @@ Feature taxonomy on the facade:
 
 ## 📦 Quick Start
 
-**Önerilen kullanım** (en temiz ve kısa makro isimleri için):
-
-```toml
-[dependencies]
-api = { package = "rustapi-rs", version = "0.2.0" }
-```
-
-Sonra kodunda:
-
-```rust
-use api::prelude::*;
-
-#[api::get("/hello")]
-async fn hello() -> &'static str {
-    "Hello from RustAPI!"
-}
-
-#[api::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    api::RustApi::auto().run("127.0.0.1:8080").await
-}
-```
-
-Eğer istersen direkt uzun isimle de kullanabilirsin:
+Add `rustapi-rs` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 rustapi-rs = "0.2.0"
 ```
 
-```rust
-use rustapi_rs::prelude::*;
-
-#[rustapi_rs::get("/hello")]
-...
-```
-
-Add `rustapi-rs` to your `Cargo.toml` (kısa isim için alias önerilir):
+You can also rename the crate if you prefer shorter macro paths:
 
 ```toml
 [dependencies]
-rustapi-rs = { version = "0.1", features = ["full"] }
+api = { package = "rustapi-rs", version = "0.2.0" }
 ```
+
+Route macros work through that alias (`#[api::get("/")]`, `use api::prelude::*`).
 
 ### The "Hello World"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the two Show HN docs blockers: a dead first-run path in CONTRIBUTING, and a mixed-language / stale-version Quick Start on the crate README that crates.io publishes.

## Description

A first-time contributor following `CONTRIBUTING.md` was told to `ls examples/` and `cargo run -p hello-world`. Those workspace packages are gone. The live path is `crates/rustapi-rs/examples/` and `cargo run -p rustapi-rs --example golden_path` (same command as `docs/GOLDEN_PATH.md`).

`crates/rustapi-rs/README.md` is what crates.io shows for `rustapi-rs` 0.2.0. The Quick Start mixed leftover Turkish copy with English and still had a `version = "0.1"` + `features = ["full"]` snippet next to the 0.2.0 path. That section is now one English 0.2.0 install (crate name + optional `api` alias), matching `docs/GETTING_STARTED.md`. The rest of the crate README is unchanged.

No code or feature changes.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #258, Fixes #259

## Testing

- [x] `ls crates/rustapi-rs/examples/` lists `golden_path.rs` (and the other in-crate examples)
- [x] `cargo run -p rustapi-rs --example golden_path` builds and serves
- [x] `GET /api/v1/ping` → `{"status":"ok"}`
- [x] `GET /live` → healthy probe JSON
- [x] `GET /docs/openapi.json` returns a spec
- [x] `crates/rustapi-rs/README.md` Quick Start is English-only, pins `0.2.0`, and has no Turkish leftover / `0.1` + `full` snippet

## Additional Notes

The stale CONTRIBUTING paths were leftover from when examples were workspace member crates under a root `examples/` directory, not from a pre-workspace layout. The project-structure tree now matches current `crates/` (`rustapi-mcp`, `rustapi-grpc`, `rustapi-testing`) and drops the old root `examples/`, `benches/`, and `memories/` entries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f86715b0-d18e-4bb4-80f2-034d19141953?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f86715b0-d18e-4bb4-80f2-034d19141953&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

