### PR TITLE
chore: fix issue templates for labels and MSRV

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: "[BUG] "
-labels: ["bug", "triage"]
+labels: ["bug"]
 assignees: []
 body:
   - type: markdown
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Rust Version
       description: What version of Rust are you using?
-      placeholder: e.g., 1.75.0
+      placeholder: e.g., 1.85.0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: RustAPI Discussions
+    url: https://github.com/Tuntii/RustAPI/discussions
+    about: Questions, ideas, and design talk that are not bug reports.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -2,7 +2,7 @@
 name: Documentation Issue
 description: Report issues with documentation
 title: "[DOCS] "
-labels: ["documentation", "triage"]
+labels: ["documentation"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement
 title: "[FEATURE] "
-labels: ["enhancement", "triage"]
+labels: ["enhancement"]
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
## Summary
Issue templates were applying a `triage` label that is not defined in the repo, so new issues landed without useful labels. The bug template also still advertised Rust 1.75.0 while MSRV is 1.85.

- Remove `triage` from bug / feature / documentation templates
- Bump the bug-template Rust placeholder to 1.85
- Add `.github/ISSUE_TEMPLATE/config.yml` with a Discussions contact link

Closes #261

## Test plan
- [ ] Open each template in the GitHub \"New issue\" UI and confirm labels resolve
- [ ] Confirm Discussions link appears when blank issues are offered