### PR TITLE
docs: align leftover MSRV copies with 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Align remaining MSRV copies with workspace `rust-version` 1.85: `CONTRACT.md`, CONTRIBUTING issue example, `cargo rustapi deploy docker --rust-version` default, and cookbook deploy docs.
+
 ## [0.2.0] - 2026-08-11
 
 First **semantic release** after dropping commit-count versioning (`0.1.<n>`). Workspace crates stay on a single version group; future bumps come from conventional commits via [release-plz](https://release-plz.dev).

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -28,7 +28,7 @@ Do not depend on internal crate APIs for long-term compatibility.
 
 ## 3. MSRV Policy
 
-- Workspace MSRV is pinned to Rust `1.78`.
+- Workspace MSRV is pinned to Rust `1.85`.
 - MSRV increases are allowed only in minor or major releases.
 - MSRV changes must be called out in changelog/release notes.
 - Patch releases must not raise MSRV.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -522,8 +522,8 @@ When reporting bugs, please include:
 Brief description of the issue
 
 ## Environment
-- Rust version: 1.75.0
-- RustAPI version: 0.1.7
+- Rust version: 1.85.0
+- RustAPI version: 0.2.0
 - OS: Windows 11
 
 ## Steps to Reproduce

--- a/crates/cargo-rustapi/src/commands/deploy.rs
+++ b/crates/cargo-rustapi/src/commands/deploy.rs
@@ -69,7 +69,7 @@ pub struct DockerArgs {
     pub output: PathBuf,
 
     /// Rust toolchain version
-    #[arg(long, default_value = "1.78")]
+    #[arg(long, default_value = "1.85")]
     pub rust_version: String,
 
     /// Binary name (defaults to package name)

--- a/docs/cookbook/src/recipes/deployment.md
+++ b/docs/cookbook/src/recipes/deployment.md
@@ -22,7 +22,7 @@ cargo rustapi deploy docker
 
 Options:
 - `--output <path>`: Output path (default: `./Dockerfile`)
-- `--rust-version <ver>`: Rust version (default: 1.78)
+- `--rust-version <ver>`: Rust version (default: 1.85)
 - `--port <port>`: Port to expose (default: 8080)
 - `--binary <name>`: Binary name (default: package name)
 


### PR DESCRIPTION
## Summary
Follow-up to #261 / #263. Issue templates were updated to MSRV 1.85, but a few live copies still said 1.75/1.78:

- `CONTRACT.md` workspace MSRV
- CONTRIBUTING issue example (Rust 1.75.0 / RustAPI 0.1.7)
- `cargo rustapi deploy docker --rust-version` default (generated Dockerfiles)
- cookbook deploy docs

Historical CHANGELOG/RELEASES entries that recorded the original 1.78 contract are left as-is.

Related: #261

## Test plan
- [x] Grep for live `1.75` / `1.78` (only historical notes + a `-1.78%` benchmark remain)
- [x] Pre-commit: `cargo fmt` + `clippy -D warnings`